### PR TITLE
Make fst work without memory mapping with an arbitrary "fake array"

### DIFF
--- a/src/automaton/mod.rs
+++ b/src/automaton/mod.rs
@@ -1,3 +1,5 @@
+use crate::fake_arr::Ulen;
+
 use self::StartsWithStateInternal::*;
 
 /// Automaton describes types that behave as a finite automaton.
@@ -143,34 +145,34 @@ impl<'a> Subsequence<'a> {
 }
 
 impl<'a> Automaton for Subsequence<'a> {
-    type State = usize;
+    type State = Ulen;
 
     #[inline]
-    fn start(&self) -> usize {
+    fn start(&self) -> Ulen {
         0
     }
 
     #[inline]
-    fn is_match(&self, &state: &usize) -> bool {
-        state == self.subseq.len()
+    fn is_match(&self, &state: &Ulen) -> bool {
+        state == self.subseq.len() as Ulen
     }
 
     #[inline]
-    fn can_match(&self, _: &usize) -> bool {
+    fn can_match(&self, _: &Ulen) -> bool {
         true
     }
 
     #[inline]
-    fn will_always_match(&self, &state: &usize) -> bool {
-        state == self.subseq.len()
+    fn will_always_match(&self, &state: &Ulen) -> bool {
+        state == self.subseq.len() as Ulen
     }
 
     #[inline]
-    fn accept(&self, &state: &usize, byte: u8) -> usize {
-        if state == self.subseq.len() {
+    fn accept(&self, &state: &Ulen, byte: u8) -> Ulen {
+        if state == self.subseq.len()  as Ulen {
             return state;
         }
-        state + (byte == self.subseq[state]) as usize
+        state + (byte == self.subseq[state as usize]) as Ulen
     }
 }
 

--- a/src/fake_arr.rs
+++ b/src/fake_arr.rs
@@ -1,15 +1,54 @@
-use std::fmt::Debug;
+use std::{
+    fmt::Debug,
+    ops::{Bound, RangeBounds},
+};
 use std::{
     io::Read,
     ops::{Index, Range, RangeFrom, RangeFull, RangeToInclusive},
 };
 
+pub fn full_slice(b: &dyn FakeArr) -> FakeArrPart<'_> {
+    return FakeArrPart {
+        real: Fuckyou::Dyn(b),
+        offset: 0,
+        len: b.len(),
+    };
+}
 pub trait FakeArr: Debug {
     fn len(&self) -> usize;
-    fn read_into(&self, buf: &mut [u8]) -> std::io::Result<usize>;
+    fn read_into(&self, offset: usize, buf: &mut [u8]) -> std::io::Result<()>;
+    fn get_ofs_len(&self, start: Bound<usize>, end: Bound<usize>) -> (usize, usize) {
+        use Bound::*;
+        let start = match start {
+            Unbounded => 0,
+            Included(i) => i,
+            Excluded(i) => panic!(),
+        };
+        let end = match end {
+            Unbounded => self.len(),
+            Included(i) => i + 1,
+            Excluded(i) => i,
+        };
+        return (start, end - start);
+    }
+    /*fn slice_w_range(&self, e: SomRang) -> FakeArrPart<'_> {
+
+    }*/
+    fn slice<'a>(&'a self, bounds: ShRange<usize>) -> FakeArrPart<'a> {
+        let (offset, len) = self.get_ofs_len(bounds.0, bounds.1);
+        FakeArrPart {
+            real: Fuckyou::Dyn(self.as_dyn()),
+            offset,
+            len,
+        }
+    }
+    fn full_slice(&self) -> FakeArrPart<'_> {
+        self.slice((..).into())
+    }
+    fn get_byte(&self, offset: usize) -> u8;
     fn actually_read_it(&self) -> Vec<u8> {
         let mut v = vec![0; self.len()];
-        self.read_into(&mut v).unwrap();
+        self.read_into(0, &mut v).unwrap();
         v
     }
     fn to_vec(&self) -> Vec<u8> {
@@ -18,6 +57,7 @@ pub trait FakeArr: Debug {
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
+    fn as_dyn(&self) -> &dyn FakeArr;
 }
 impl<'a> PartialEq for dyn FakeArr + 'a {
     fn eq(&self, other: &Self) -> bool {
@@ -26,42 +66,110 @@ impl<'a> PartialEq for dyn FakeArr + 'a {
 }
 impl Read for &dyn FakeArr {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        (*self).read_into(buf)
+        (*self).read_into(0, buf).map(|()| buf.len())
     }
 }
 
-impl<'a> Index<usize> for FakeArr + 'a {
-    type Output = u8;
+#[macro_export]
+macro_rules! slic {
+    ($($e:ident).+ [$x:tt..]) => (($($e).*).slice(($x..).into()));
+    ($($e:ident).+ [$x:tt..$y:tt]) => (($($e).*).slice(($x..$y).into()));
+    ($($e:ident).+ [..=$y:tt]) => (($($e).*).slice((..=$y).into()));
+    ($($e:ident).+ [..]) =>(($($e).*).slice((..).into()));
+    ($($e:ident).+ [$x:tt]) => (($($e).*).get_byte($x));
+}
+#[macro_export]
+macro_rules! slic2 {
+    ($($e:ident).+ [$x:tt..]) => (($($e).*).slice2(($x..).into()));
+    ($($e:ident).+ [$x:tt..$y:tt]) => (($($e).*).slice2(($x..$y).into()));
+    ($($e:ident).+ [..=$y:tt]) => (($($e).*).slice2((..=$y).into()));
+    ($($e:ident).+ [..]) =>(($($e).*).slice2((..).into()));
+    ($($e:ident).+ [$x:tt]) => (($($e).*).get_byte($x));
+}
+pub struct ShRange<T>(Bound<T>, Bound<T>);
 
-    fn index(&self, index: usize) -> &Self::Output {
-        let mut out: u8 = 0;
-        self[index..index + 1].read_into(std::slice::from_mut(&mut out));
-        return &out;
+fn bound_cloned<T: Clone>(b: Bound<&T>) -> Bound<T> {
+    match b {
+        Bound::Unbounded => Bound::Unbounded,
+        Bound::Included(x) => Bound::Included(x.clone()),
+        Bound::Excluded(x) => Bound::Excluded(x.clone()),
     }
 }
-impl<'a> Index<RangeFrom<usize>> for FakeArr + 'a {
-    type Output = FakeArr + 'a;
+impl<T: Clone> From<Range<T>> for ShRange<T> {
+    fn from(r: Range<T>) -> Self {
+        ShRange(bound_cloned(r.start_bound()), bound_cloned(r.end_bound()))
+    }
+}
+impl<T: Clone> From<RangeFull> for ShRange<T> {
+    fn from(r: RangeFull) -> Self {
+        ShRange(bound_cloned(r.start_bound()), bound_cloned(r.end_bound()))
+    }
+}
+impl<T: Clone> From<RangeFrom<T>> for ShRange<T> {
+    fn from(r: RangeFrom<T>) -> Self {
+        ShRange(bound_cloned(r.start_bound()), bound_cloned(r.end_bound()))
+    }
+}
+impl<T: Clone> From<RangeToInclusive<T>> for ShRange<T> {
+    fn from(r: RangeToInclusive<T>) -> Self {
+        ShRange(bound_cloned(r.start_bound()), bound_cloned(r.end_bound()))
+    }
+}
 
-    fn index(&self, index: RangeFrom<usize>) -> &Self::Output {
+#[derive(Debug, Clone, Copy)]
+// idk why, but i can't figure out why this can't just be &'a dyn FakeArr
+enum Fuckyou<'a> {
+    Dyn(&'a dyn FakeArr),
+    Slic(&'a [u8]),
+}
+impl<'a> Fuckyou<'a> {
+    fn as_dyn(&self) -> &dyn FakeArr {
+        match &self {
+            Fuckyou::Dyn(e) => *e,
+            Fuckyou::Slic(e) => e.as_dyn(),
+        }
+    }
+}
+#[derive(Debug, Clone, Copy)]
+pub struct FakeArrPart<'a> {
+    real: Fuckyou<'a>,
+    offset: usize,
+    len: usize,
+}
+impl<'a> FakeArrPart<'a> {
+    // the same as .slice, but returns a thing of the lifetime of the root real fake array instead of this part so the returned part can live longer than this one
+    pub fn slice2(&self, b: ShRange<usize>) -> FakeArrPart<'a> {
+        let (start, len) = self.get_ofs_len(b.0, b.1);
+        return FakeArrPart {
+            real: self.real,
+            offset: self.offset + start,
+            len,
+        };
+    }
+}
+impl<'a> FakeArr for FakeArrPart<'a> {
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn read_into(&self, offset: usize, buf: &mut [u8]) -> std::io::Result<()> {
+        self.real.as_dyn().read_into(self.offset + offset, buf)
+    }
+
+    fn get_byte(&self, offset: usize) -> u8 {
+        self.real.as_dyn().get_byte(self.offset + offset)
+    }
+
+    fn slice(&self, b: ShRange<usize>) -> FakeArrPart<'a> {
+        self.slice2(b)
+    }
+
+    fn as_dyn(&self) -> &dyn FakeArr {
         todo!()
     }
 }
-impl<'a> Index<RangeToInclusive<usize>> for FakeArr + 'a {
-    type Output = FakeArr + 'a;
 
-    fn index(&self, index: RangeToInclusive<usize>) -> &Self::Output {
-        todo!()
-    }
-}
-impl<'a> Index<Range<usize>> for FakeArr + 'a {
-    type Output = FakeArr + 'a;
-
-    fn index(&self, index: Range<usize>) -> &Self::Output {
-        todo!()
-    }
-}
-
-pub type FakeArrRef<'a> = &'a (dyn FakeArr);
+pub type FakeArrRef<'a> = FakeArrPart<'a>;
 /*#[derive(Clone, Copy)]
 pub struct FakeArrRef<'a> {
     arr: &'a dyn FakeArr,
@@ -118,40 +226,95 @@ impl FakeArr for Vec<u8> {
         self.len()
     }
 
-    fn actually_read_it(&self) -> Vec<u8> {
-        return self.to_vec();
+    fn read_into(&self, offset: usize, buf: &mut [u8]) -> std::io::Result<()> {
+        buf.copy_from_slice(&self[offset..offset + buf.len()]);
+        Ok(())
     }
 
-    fn read_into(&self, buf: &mut [u8]) -> std::io::Result<usize> {
-        (&self[..]).read(buf)
+    fn get_byte(&self, offset: usize) -> u8 {
+        self[offset]
+    }
+
+    fn as_dyn(&self) -> &dyn FakeArr {
+        self
     }
 }
 
-impl FakeArr for [u8] {
+impl FakeArr for &[u8] {
     fn len(&self) -> usize {
-        return self.len();
+        return (self as &[u8]).len();
     }
 
-    fn actually_read_it(&self) -> Vec<u8> {
-        return self.to_vec();
+    fn read_into(&self, offset: usize, buf: &mut [u8]) -> std::io::Result<()> {
+        buf.copy_from_slice(&self[offset..offset + buf.len()]);
+        Ok(())
     }
 
-    fn read_into(&self, buf: &mut [u8]) -> std::io::Result<usize> {
-        panic!();
-        // std::io::Read::read(&mut self, buf)
+    fn get_byte(&self, offset: usize) -> u8 {
+        self[offset]
+    }
+
+    /*fn slice(&self, bounds: ShRange<usize>) -> FakeArrPart<'_> {
+        let (start, len) = self.get_ofs_len(bounds.0, bounds.1);
+        slice_to_fake_arr(&self[start..start + len])
+    }*/
+    fn as_dyn(&self) -> &dyn FakeArr {
+        self
     }
 }
 
-pub const EMPTY: &'static dyn FakeArr = &vec![];
+/*#[derive(Debug, Clone, Copy)]
+pub struct FakeArrSlice<'a> {
+    real: &'a [u8],
+    offset: usize,
+    len: usize,
+}
+impl<'a> FakeArr for FakeArrSlice<'a> {
+    fn len(&self) -> usize {
+        todo!()
+    }
 
-struct FakeArrFromSlice<'a> {
-    slice: &'a [u8],
+    fn read_into(&self, offset: usize, buf: &mut [u8]) -> std::io::Result<usize> {
+        todo!()
+    }
+
+    fn slice(&self, b: ShRange<usize>) -> FakeArrPart {
+        todo!()
+    }
+
+    fn get_byte(&self, offset: usize) -> u8 {
+        todo!()
+    }
+
+    fn as_dyn(&self) -> &dyn FakeArr {
+        todo!()
+    }
+
+}*/
+
+const EMPTY1: &[u8; 0] = &[];
+/*pub const EMPTY2: FakeArrSlice = FakeArrSlice {
+    real: EMPTY1,
+    offset: 0,
+    len: 0,
+};*/
+pub fn empty() -> FakeArrPart<'static> {
+    let x = FakeArrPart {
+        real: Fuckyou::Slic(EMPTY1),
+        offset: 0,
+        len: 0,
+    };
+    x
 }
 
 pub fn slice_to_fake_arr<'a>(slice: &'a [u8]) -> FakeArrRef<'a> {
-    //let s = std::mem::leak(slice);
-    panic!();
-    // slice
+    // slice.as_dyn().slice((..).into())
+    println!("slice_to_fake_arr: {:?}", slice);
+    FakeArrPart {
+        real: Fuckyou::Slic(slice),
+        offset: 0,
+        len: slice.len(),
+    }
 }
 /*pub fn slice_to_fake_arr(slice: &[u8]) -> FakeArrFromSlice {
     FakeArrFromSlice { slice }

--- a/src/fake_arr.rs
+++ b/src/fake_arr.rs
@@ -45,7 +45,9 @@ pub trait FakeArr: Debug {
     fn full_slice(&self) -> FakeArrPart<'_> {
         self.slice((..).into())
     }
-    fn get_byte(&self, offset: usize) -> u8;
+    fn get_byte(&self, offset: usize) -> u8 {
+        self.slice((offset..offset + 1).into()).actually_read_it()[0]
+    }
     fn actually_read_it(&self) -> Vec<u8> {
         let mut v = vec![0; self.len()];
         self.read_into(0, &mut v).unwrap();
@@ -156,9 +158,9 @@ impl<'a> FakeArr for FakeArrPart<'a> {
         self.real.as_dyn().read_into(self.offset + offset, buf)
     }
 
-    fn get_byte(&self, offset: usize) -> u8 {
+    /*fn get_byte(&self, offset: usize) -> u8 {
         self.real.as_dyn().get_byte(self.offset + offset)
-    }
+    }*/
 
     fn slice(&self, b: ShRange<usize>) -> FakeArrPart<'a> {
         self.slice2(b)
@@ -231,9 +233,9 @@ impl FakeArr for Vec<u8> {
         Ok(())
     }
 
-    fn get_byte(&self, offset: usize) -> u8 {
+    /*fn get_byte(&self, offset: usize) -> u8 {
         self[offset]
-    }
+    }*/
 
     fn as_dyn(&self) -> &dyn FakeArr {
         self
@@ -250,9 +252,9 @@ impl FakeArr for &[u8] {
         Ok(())
     }
 
-    fn get_byte(&self, offset: usize) -> u8 {
+    /*fn get_byte(&self, offset: usize) -> u8 {
         self[offset]
-    }
+    }*/
 
     /*fn slice(&self, bounds: ShRange<usize>) -> FakeArrPart<'_> {
         let (start, len) = self.get_ofs_len(bounds.0, bounds.1);

--- a/src/fake_arr.rs
+++ b/src/fake_arr.rs
@@ -1,0 +1,168 @@
+use std::fmt::Debug;
+use std::{
+    io::Read,
+    ops::{Index, Range, RangeFrom, RangeFull, RangeToInclusive},
+};
+
+pub trait FakeArr: Debug {
+    fn len(&self) -> usize;
+    fn read_into(&self, buf: &mut [u8]) -> std::io::Result<usize>;
+    fn actually_read_it(&self) -> Vec<u8> {
+        let mut v = vec![0; self.len()];
+        self.read_into(&mut v).unwrap();
+        v
+    }
+    fn to_vec(&self) -> Vec<u8> {
+        self.actually_read_it()
+    }
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+impl<'a> PartialEq for dyn FakeArr + 'a {
+    fn eq(&self, other: &Self) -> bool {
+        return &self.to_vec()[..] == &other.to_vec()[..];
+    }
+}
+impl Read for &dyn FakeArr {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        (*self).read_into(buf)
+    }
+}
+
+impl<'a> Index<usize> for FakeArr + 'a {
+    type Output = u8;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        let mut out: u8 = 0;
+        self[index..index + 1].read_into(std::slice::from_mut(&mut out));
+        return &out;
+    }
+}
+impl<'a> Index<RangeFrom<usize>> for FakeArr + 'a {
+    type Output = FakeArr + 'a;
+
+    fn index(&self, index: RangeFrom<usize>) -> &Self::Output {
+        todo!()
+    }
+}
+impl<'a> Index<RangeToInclusive<usize>> for FakeArr + 'a {
+    type Output = FakeArr + 'a;
+
+    fn index(&self, index: RangeToInclusive<usize>) -> &Self::Output {
+        todo!()
+    }
+}
+impl<'a> Index<Range<usize>> for FakeArr + 'a {
+    type Output = FakeArr + 'a;
+
+    fn index(&self, index: Range<usize>) -> &Self::Output {
+        todo!()
+    }
+}
+
+pub type FakeArrRef<'a> = &'a (dyn FakeArr);
+/*#[derive(Clone, Copy)]
+pub struct FakeArrRef<'a> {
+    arr: &'a dyn FakeArr,
+}
+impl FakeArrRef<'_> {
+    fn new(arr: &dyn FakeArr) -> FakeArrRef {
+        FakeArrRef { arr }
+    }
+}
+
+impl<'a> std::ops::Deref for FakeArrRef<'a> {
+    type Target = dyn FakeArr + 'a;
+
+    fn deref(&self) -> &Self::Target {
+        self.arr
+    }
+}
+
+impl Index<usize> for FakeArrRef<'_> {
+    type Output = u8;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        todo!()
+    }
+}
+impl Index<RangeFrom<usize>> for FakeArrRef<'_> {
+    type Output = [u8];
+
+    fn index(&self, index: RangeFrom<usize>) -> &Self::Output {
+        todo!()
+    }
+}
+impl Index<RangeToInclusive<usize>> for FakeArrRef<'_> {
+    type Output = [u8];
+
+    fn index(&self, index: RangeToInclusive<usize>) -> &Self::Output {
+        todo!()
+    }
+}
+impl Index<Range<usize>> for FakeArrRef<'_> {
+    type Output = [u8];
+
+    fn index(&self, index: Range<usize>) -> &Self::Output {
+        todo!()
+    }
+}*/
+
+/*impl Index<RangeFull<usize>> for FakeArr {
+    type Output = [u8];
+}*/
+
+impl FakeArr for Vec<u8> {
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn actually_read_it(&self) -> Vec<u8> {
+        return self.to_vec();
+    }
+
+    fn read_into(&self, buf: &mut [u8]) -> std::io::Result<usize> {
+        (&self[..]).read(buf)
+    }
+}
+
+impl FakeArr for [u8] {
+    fn len(&self) -> usize {
+        return self.len();
+    }
+
+    fn actually_read_it(&self) -> Vec<u8> {
+        return self.to_vec();
+    }
+
+    fn read_into(&self, buf: &mut [u8]) -> std::io::Result<usize> {
+        panic!();
+        // std::io::Read::read(&mut self, buf)
+    }
+}
+
+pub const EMPTY: &'static dyn FakeArr = &vec![];
+
+struct FakeArrFromSlice<'a> {
+    slice: &'a [u8],
+}
+
+pub fn slice_to_fake_arr<'a>(slice: &'a [u8]) -> FakeArrRef<'a> {
+    //let s = std::mem::leak(slice);
+    panic!();
+    // slice
+}
+/*pub fn slice_to_fake_arr(slice: &[u8]) -> FakeArrFromSlice {
+    FakeArrFromSlice { slice }
+}*/
+/*impl<'a> FakeArr for FakeArrFromSlice<'a> {
+    fn len(&self) -> usize {
+        todo!()
+    }
+
+    fn actually_read_it(&self) -> Vec<u8> {
+        todo!()
+    }
+}
+*/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ mod regex;
 mod fake_arr;
 
 pub use self::regex::Regex;
-pub use fake_arr::{FakeArr, ShRange, FakeArrPart};
+pub use fake_arr::{FakeArr, ShRange, FakeArrSlice};
 
 mod error;
 #[path = "automaton/mod.rs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod regex;
 mod fake_arr;
 
 pub use self::regex::Regex;
+pub use fake_arr::{FakeArr, ShRange, FakeArrPart};
 
 mod error;
 #[path = "automaton/mod.rs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ mod regex;
 mod fake_arr;
 
 pub use self::regex::Regex;
-pub use fake_arr::{FakeArr, ShRange, FakeArrSlice};
+pub use fake_arr::{FakeArr, ShRange, FakeArrSlice, Ulen};
 
 mod error;
 #[path = "automaton/mod.rs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub use crate::map::{Map, MapBuilder};
 pub use crate::stream::{IntoStreamer, Streamer};
 
 mod regex;
+mod fake_arr;
 
 pub use self::regex::Regex;
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -53,7 +53,7 @@ use std::ops::Deref;
 /// Keys will always be byte strings; however, we may grow more conveniences
 /// around dealing with them (such as a serialization/deserialization step,
 /// although it isn't clear where exactly this should live).
-pub struct Map<Data: Deref<Target = dyn FakeArr>>(raw::Fst<Data>);
+pub struct Map<Data: Deref<Target = dyn FakeArr> = Box<dyn FakeArr>>(raw::Fst<Data>);
 
 impl<Data: Deref<Target = dyn FakeArr>> Map<Data> {
     /// Tests the membership of a single key.

--- a/src/map.rs
+++ b/src/map.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::io;
 use std::iter::FromIterator;
 
-use crate::{automaton::{AlwaysMatch, Automaton}, fake_arr::{FakeArr, FakeArrRef}};
+use crate::{automaton::{AlwaysMatch, Automaton}, fake_arr::{FakeArr, FakeArrRef, Ulen}};
 use crate::raw;
 pub use crate::raw::IndexedValue;
 use crate::stream::{IntoStreamer, Streamer};
@@ -258,7 +258,7 @@ impl<Data: FakeArr> Map<Data> {
 
     /// Returns the number of elements in this map.
     #[inline]
-    pub fn len(&self) -> usize {
+    pub fn len(&self) -> Ulen {
         self.0.len()
     }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -53,9 +53,9 @@ use std::ops::Deref;
 /// Keys will always be byte strings; however, we may grow more conveniences
 /// around dealing with them (such as a serialization/deserialization step,
 /// although it isn't clear where exactly this should live).
-pub struct Map<Data: Deref<Target = dyn FakeArr> = Box<dyn FakeArr>>(raw::Fst<Data>);
+pub struct Map<Data: FakeArr>(raw::Fst<Data>);
 
-impl<Data: Deref<Target = dyn FakeArr>> Map<Data> {
+impl<Data: FakeArr> Map<Data> {
     /// Tests the membership of a single key.
     ///
     /// # Example
@@ -323,7 +323,7 @@ impl<Data: Deref<Target = dyn FakeArr>> Map<Data> {
     }
 }
 
-impl<Data: Deref<Target=dyn FakeArr>> fmt::Debug for Map<Data> {
+impl<Data: FakeArr> fmt::Debug for Map<Data> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Map([")?;
         let mut stream = self.stream();
@@ -340,7 +340,7 @@ impl<Data: Deref<Target=dyn FakeArr>> fmt::Debug for Map<Data> {
 }
 
 // Construct a map from an Fst object.
-impl<Data: Deref<Target=dyn FakeArr>> From<raw::Fst<Data>> for Map<Data> {
+impl<Data: FakeArr> From<raw::Fst<Data>> for Map<Data> {
     #[inline]
     fn from(fst: raw::Fst<Data>) -> Self {
         Map(fst)
@@ -348,14 +348,14 @@ impl<Data: Deref<Target=dyn FakeArr>> From<raw::Fst<Data>> for Map<Data> {
 }
 
 /// Returns the underlying finite state transducer.
-impl<Data: Deref<Target=dyn FakeArr>> AsRef<raw::Fst<Data>> for Map<Data> {
+impl<Data: FakeArr> AsRef<raw::Fst<Data>> for Map<Data> {
     #[inline]
     fn as_ref(&self) -> &raw::Fst<Data> {
         &self.0
     }
 }
 
-impl<'m, 'a, Data: Deref<Target = dyn FakeArr>> IntoStreamer<'a> for &'m Map<Data> {
+impl<'m, 'a, Data: FakeArr> IntoStreamer<'a> for &'m Map<Data> {
     type Item = (FakeArrRef<'a>, u64);
     type Into = Stream<'m>;
 

--- a/src/raw/build.rs
+++ b/src/raw/build.rs
@@ -2,7 +2,7 @@ use std::io::{self, Write};
 
 use byteorder::{LittleEndian, WriteBytesExt};
 
-use crate::error::Result;
+use crate::{error::Result, fake_arr::FakeArrRef};
 use crate::raw::counting_writer::CountingWriter;
 use crate::raw::error::Error;
 use crate::raw::registry::{Registry, RegistryEntry};
@@ -184,12 +184,12 @@ impl<W: io::Write> Builder<W> {
     /// writing to the underlying writer, an error is returned.
     pub fn extend_stream<'f, I, S>(&mut self, stream: I) -> Result<()>
     where
-        I: for<'a> IntoStreamer<'a, Into = S, Item = (&'a [u8], Output)>,
-        S: 'f + for<'a> Streamer<'a, Item = (&'a [u8], Output)>,
+        I: for<'a> IntoStreamer<'a, Into = S, Item = (FakeArrRef<'a>, Output)>,
+        S: 'f + for<'a> Streamer<'a, Item = (FakeArrRef<'a>, Output)>,
     {
         let mut stream = stream.into_stream();
         while let Some((key, out)) = stream.next() {
-            self.insert(key, out.value())?;
+            self.insert(key.actually_read_it(), out.value())?;
         }
         Ok(())
     }

--- a/src/raw/build.rs
+++ b/src/raw/build.rs
@@ -9,6 +9,7 @@ use crate::raw::registry::{Registry, RegistryEntry};
 use crate::raw::{CompiledAddr, FstType, Output, Transition, EMPTY_ADDRESS, NONE_ADDRESS, VERSION};
 // use raw::registry_minimal::{Registry, RegistryEntry};
 use crate::stream::{IntoStreamer, Streamer};
+use crate::fake_arr::FakeArr;
 
 /// A builder for creating a finite state transducer.
 ///

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -33,7 +33,7 @@ use crate::{
 };
 use crate::{error::Result, slic};
 use crate::{
-    fake_arr::{full_slice, FakeArrPart, ShRange},
+    fake_arr::{full_slice, FakeArrSlice, ShRange},
     stream::{IntoStreamer, Streamer},
 };
 
@@ -327,7 +327,7 @@ impl<Data: FakeArr> Fst<Data> {
         // unexpected EOF. However, we are reading from a byte slice (no
         // IO errors possible) and we've confirmed the byte slice is at least
         // N bytes (no unexpected EOF).
-        let mut flonk = &slic!(data[0..]) as &dyn FakeArr;
+        let mut flonk = slic!(data[0..]);
 
         let version = flonk.read_u64::<LittleEndian>().unwrap();
         if version == 0 || version > VERSION {
@@ -337,15 +337,15 @@ impl<Data: FakeArr> Fst<Data> {
             }
             .into());
         }
-        let mut bonk = &slic!(data[8..]) as &dyn FakeArr;
+        let mut bonk = slic!(data[8..]);
         let ty = bonk.read_u64::<LittleEndian>().unwrap();
         let root_addr = {
-            let mut last = &slic!(data[(data.len() - 8)..]) as &dyn FakeArr;
-            println!("len={}, d={:#?}, data={:?}, full={:#?}", data.len(), last, last.to_vec(), data.to_vec());
+            let mut last = slic!(data[(data.len() - 8)..]);
+            // println!("len={}, d={:#?}, data={:?}, full={:#?}", data.len(), last, last.to_vec(), data.to_vec());
             u64_to_usize(last.read_u64::<LittleEndian>().unwrap())
         };
         let len = {
-            let mut last2 = &slic!(data[(data.len() - 16)..]) as &dyn FakeArr;
+            let mut last2 = slic!(data[(data.len() - 16)..]);
             u64_to_usize(last2.read_u64::<LittleEndian>().unwrap())
         };
         println!("root={}, len={}", root_addr, len);
@@ -1202,7 +1202,7 @@ impl FakeArr for Buffer {
         self.buf[offset]
     }
 
-    fn slice<'a>(&'a self, b: ShRange<usize>) -> FakeArrPart<'a> {
+    fn slice<'a>(&'a self, b: ShRange<usize>) -> FakeArrSlice<'a> {
         let x = full_slice(self);
         x.slice2(b)
     }

--- a/src/raw/node.rs
+++ b/src/raw/node.rs
@@ -658,7 +658,7 @@ impl StateAnyTrans {
                         - self.ntrans_len()
                         - 1 // pack size
                         - self.trans_index_size(node.version, node.ntrans);
-            let i = node.data.get_byte((start + b as usize).into()) as usize;
+            let i = node.data.get_byte((start + b as usize)) as usize;
             if i >= node.ntrans {
                 None
             } else {

--- a/src/raw/node.rs
+++ b/src/raw/node.rs
@@ -856,7 +856,7 @@ mod tests {
             for word in &bs {
                 bfst.add(word).unwrap();
             }
-            let fst = Fst::new_box(bfst.into_inner().unwrap()).unwrap();
+            let fst = Fst::new(bfst.into_inner().unwrap()).unwrap();
             let mut rdr = fst.stream();
             let mut words = vec![];
             while let Some(w) = rdr.next() {

--- a/src/raw/ops.rs
+++ b/src/raw/ops.rs
@@ -466,7 +466,7 @@ mod tests {
     use crate::raw::tests::{fst_map, fst_set};
     use crate::raw::Fst;
     use crate::stream::{IntoStreamer, Streamer};
-
+    use crate::fake_arr::FakeArr;
     use super::OpBuilder;
 
     fn s(string: &str) -> String {

--- a/src/raw/pack.rs
+++ b/src/raw/pack.rs
@@ -2,10 +2,7 @@ use std::io;
 
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
 
-use crate::{
-    fake_arr::{FakeArr, FakeArrRef},
-    slic,
-};
+use crate::{fake_arr::{FakeArr, FakeArrRef, Ulen}, slic};
 
 /// pack_uint packs the given integer in the smallest number of bytes possible,
 /// and writes it to the given writer. The number of bytes written is returned
@@ -32,7 +29,7 @@ pub fn pack_uint_in<W: io::Write>(mut wtr: W, n: u64, nbytes: u8) -> io::Result<
 #[inline(always)]
 pub fn unpack_uint(slice: FakeArrRef<'_>, nbytes: u8) -> u64 {
     LittleEndian::read_uint(
-        &slic!(slice[0..(nbytes as usize)]).actually_read_it(),
+        &slic!(slice[0..(nbytes as Ulen)]).actually_read_it(),
         nbytes as usize,
     )
 }

--- a/src/raw/pack.rs
+++ b/src/raw/pack.rs
@@ -2,7 +2,10 @@ use std::io;
 
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
 
-use crate::fake_arr::FakeArrRef;
+use crate::{
+    fake_arr::{FakeArr, FakeArrRef},
+    slic,
+};
 
 /// pack_uint packs the given integer in the smallest number of bytes possible,
 /// and writes it to the given writer. The number of bytes written is returned
@@ -28,7 +31,10 @@ pub fn pack_uint_in<W: io::Write>(mut wtr: W, n: u64, nbytes: u8) -> io::Result<
 /// `nbytes` must be >= 1 and <= 8.
 #[inline(always)]
 pub fn unpack_uint(slice: FakeArrRef<'_>, nbytes: u8) -> u64 {
-    LittleEndian::read_uint(&slice[0..nbytes as usize].actually_read_it(), nbytes as usize)
+    LittleEndian::read_uint(
+        &slic!(slice[0..(nbytes as usize)]).actually_read_it(),
+        nbytes as usize,
+    )
 }
 
 /// pack_size returns the smallest number of bytes that can encode `n`.
@@ -54,6 +60,8 @@ pub fn pack_size(n: u64) -> u8 {
 
 #[cfg(test)]
 mod tests {
+    use crate::fake_arr::slice_to_fake_arr;
+
     use super::*;
     use quickcheck::{QuickCheck, StdGen};
     use std::io;
@@ -64,7 +72,7 @@ mod tests {
             let mut buf = io::Cursor::new(vec![]);
             let size = pack_uint(&mut buf, num).unwrap();
             buf.set_position(0);
-            num == unpack_uint(buf.get_ref(), size)
+            num == unpack_uint(slice_to_fake_arr(buf.get_ref()), size)
         }
         QuickCheck::new()
             .gen(StdGen::new(::rand::thread_rng(), 257)) // pick byte boundary

--- a/src/raw/pack.rs
+++ b/src/raw/pack.rs
@@ -2,6 +2,8 @@ use std::io;
 
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
 
+use crate::fake_arr::FakeArrRef;
+
 /// pack_uint packs the given integer in the smallest number of bytes possible,
 /// and writes it to the given writer. The number of bytes written is returned
 /// on success.
@@ -25,8 +27,8 @@ pub fn pack_uint_in<W: io::Write>(mut wtr: W, n: u64, nbytes: u8) -> io::Result<
 ///
 /// `nbytes` must be >= 1 and <= 8.
 #[inline(always)]
-pub fn unpack_uint(slice: &[u8], nbytes: u8) -> u64 {
-    LittleEndian::read_uint(slice, nbytes as usize)
+pub fn unpack_uint(slice: FakeArrRef<'_>, nbytes: u8) -> u64 {
+    LittleEndian::read_uint(&slice[0..nbytes as usize].actually_read_it(), nbytes as usize)
 }
 
 /// pack_size returns the smallest number of bytes that can encode `n`.

--- a/src/raw/registry.rs
+++ b/src/raw/registry.rs
@@ -1,4 +1,4 @@
-use crate::raw::build::BuilderNode;
+use crate::{raw::build::BuilderNode};
 use crate::raw::{CompiledAddr, NONE_ADDRESS};
 
 #[derive(Debug)]

--- a/src/raw/tests.rs
+++ b/src/raw/tests.rs
@@ -32,7 +32,7 @@ where
     for s in ss.iter().into_iter() {
         bfst.add(s).unwrap();
     }
-    let fst = Fst::new(Box::new(bfst.into_inner().unwrap()) as Box<dyn FakeArr>).unwrap();
+    let fst = Fst::new(bfst.into_inner().unwrap()).unwrap();
     ss.dedup();
     assert_eq!(fst.len(), ss.len());
     fst
@@ -54,7 +54,7 @@ where
         bfst.insert(s, o).unwrap();
     }
     let d = bfst.into_inner().unwrap();
-    Fst::new(Box::new(d) as Box<FakeArr>).unwrap()
+    Fst::new(d).unwrap()
 }
 
 pub fn fst_inputs(fst: &Fst) -> Vec<Vec<u8>> {
@@ -221,7 +221,7 @@ fn fst_map_100000_lengths() {
 
 #[test]
 fn invalid_version() {
-    match Fst::new_box(vec![0; 32]) {
+    match Fst::new(vec![0; 32]) {
         Err(Error::Fst(raw::Error::Version { got, .. })) => assert_eq!(got, 0),
         Err(err) => panic!("expected version error, got {:?}", err),
         Ok(_) => panic!("expected version error, got FST"),
@@ -234,7 +234,7 @@ fn invalid_version_crate_too_old() {
 
     let mut buf = vec![0; 32];
     LittleEndian::write_u64(&mut buf, VERSION + 1);
-    match Fst::new_box(buf) {
+    match Fst::new(buf) {
         Err(Error::Fst(raw::Error::Version { got, .. })) => {
             assert_eq!(got, VERSION + 1);
         }
@@ -245,7 +245,7 @@ fn invalid_version_crate_too_old() {
 
 #[test]
 fn invalid_format() {
-    match Fst::new_box(vec![0; 0]) {
+    match Fst::new(vec![0; 0]) {
         Err(Error::Fst(raw::Error::Format)) => {}
         Err(err) => panic!("expected format error, got {:?}", err),
         Ok(_) => panic!("expected format error, got FST"),

--- a/src/raw/tests.rs
+++ b/src/raw/tests.rs
@@ -34,7 +34,7 @@ where
     }
     let fst = Fst::new(bfst.into_inner().unwrap()).unwrap();
     ss.dedup();
-    assert_eq!(fst.len(), ss.len());
+    assert_eq!(fst.len() as usize, ss.len());
     fst
 }
 


### PR DESCRIPTION
A better description is here: https://github.com/tantivy-search/tantivy/pull/1067

This allows fst to work without having the whole index in memory and on systems without memory mapping supported (e.g. WASM).

To make this viable for everything else, the dynamic invocation needs to be removed again or put behind a compile time flag.