### PR TITLE
Add support for ^ and $ anchors in regular expressions

### DIFF
--- a/src/regex/compile.rs
+++ b/src/regex/compile.rs
@@ -96,7 +96,17 @@ impl Compiler {
                     self.set_split(split, j2, j3);
                 }
             }
-            HirKind::Look(_) => return Err(Error::NoEmpty),
+            HirKind::Look(look) => {
+                match look {
+                    regex_syntax::hir::Look::Start => {
+                        self.push(Inst::StartText);
+                    }
+                    regex_syntax::hir::Look::End => {
+                        self.push(Inst::EndText);
+                    }
+                    _ => return Err(Error::NoWordBoundary),
+                }
+            }
         }
         self.check_size()
     }

--- a/src/regex/dfa.rs
+++ b/src/regex/dfa.rs
@@ -21,8 +21,6 @@ struct State {
     insts: Vec<usize>,
     next: [Option<usize>; 256],
     is_match: bool,
-    at_start: bool,
-    at_end: bool,
 }
 
 impl DfaBuilder {
@@ -107,8 +105,6 @@ impl DfaBuilder {
                     insts,
                     next: [None; 256],
                     is_match,
-                    at_start: false,
-                    at_end: false,
                 });
                 *v.insert(self.dfa.states.len() - 1)
             }
@@ -148,7 +144,14 @@ impl Dfa {
         }
     }
 
-    fn run(&self, from: &SparseSet, to: &mut SparseSet, byte: Option<u8>, at_start: bool, at_end: bool) -> bool {
+    fn run(
+        &self,
+        from: &SparseSet,
+        to: &mut SparseSet,
+        byte: Option<u8>,
+        at_start: bool,
+        at_end: bool,
+    ) -> bool {
         use super::Inst::*;
         to.clear();
         let mut is_match = false;

--- a/src/regex/dfa.rs
+++ b/src/regex/dfa.rs
@@ -21,6 +21,8 @@ struct State {
     insts: Vec<usize>,
     next: [Option<usize>; 256],
     is_match: bool,
+    at_start: bool,
+    at_end: bool,
 }
 
 impl DfaBuilder {
@@ -69,7 +71,7 @@ impl DfaBuilder {
         for &ip in &self.dfa.states[state].insts {
             cur.add(ip);
         }
-        self.dfa.run(cur, next, byte);
+        self.dfa.run(cur, next, Some(byte), false, false);
         let next_state = self.cached_state(next);
         self.dfa.states[state].next[byte as usize] = next_state;
         next_state
@@ -92,6 +94,7 @@ impl DfaBuilder {
                     is_match = true;
                     insts.push(ip);
                 }
+                StartText | EndText => insts.push(ip),
             }
         }
         if insts.is_empty() {
@@ -104,6 +107,8 @@ impl DfaBuilder {
                     insts,
                     next: [None; 256],
                     is_match,
+                    at_start: false,
+                    at_end: false,
                 });
                 *v.insert(self.dfa.states.len() - 1)
             }
@@ -134,10 +139,16 @@ impl Dfa {
                 self.add(set, ip1);
                 self.add(set, ip2);
             }
+            StartText => {
+                self.add(set, ip + 1);
+            }
+            EndText => {
+                self.add(set, ip + 1);
+            }
         }
     }
 
-    fn run(&self, from: &SparseSet, to: &mut SparseSet, byte: u8) -> bool {
+    fn run(&self, from: &SparseSet, to: &mut SparseSet, byte: Option<u8>, at_start: bool, at_end: bool) -> bool {
         use super::Inst::*;
         to.clear();
         let mut is_match = false;
@@ -147,7 +158,19 @@ impl Dfa {
                 Jump(_) | Split(_, _) => {}
                 Match => is_match = true,
                 Range(s, e) => {
-                    if s <= byte && byte <= e {
+                    if let Some(b) = byte {
+                        if s <= b && b <= e {
+                            self.add(to, ip + 1);
+                        }
+                    }
+                }
+                StartText => {
+                    if at_start {
+                        self.add(to, ip + 1);
+                    }
+                }
+                EndText => {
+                    if at_end {
                         self.add(to, ip + 1);
                     }
                 }

--- a/src/regex/error.rs
+++ b/src/regex/error.rs
@@ -28,11 +28,6 @@ pub enum Error {
     ///
     /// This restriction may be lifted in the future.
     NoWordBoundary,
-    /// Empty or "zero width assertions" such as `^` or `$` are currently
-    /// not allowed.
-    ///
-    /// This restriction may be lifted in the future.
-    NoEmpty,
     /// Byte literals such as `(?-u:\xff)` are not allowed.
     ///
     /// This restriction may be lifted in the future.
@@ -49,7 +44,7 @@ impl From<regex_syntax::Error> for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::Error::*;
-        match *self {
+        match self {
             Syntax(ref err) => err.fmt(f),
             CompiledTooBig(size_limit) => write!(
                 f,
@@ -70,11 +65,6 @@ impl fmt::Display for Error {
                 f,
                 "Word boundary operators are not \
                  allowed."
-            ),
-            NoEmpty => write!(
-                f,
-                "Empty match operators are not allowed \
-                 (hopefully temporary)."
             ),
             NoBytes => write!(f, "Byte literals are not allowed."),
         }


### PR DESCRIPTION
This PR adds support for the `^` (start of text) and `$` (end of text) anchors in our regular expression engine. I introduced explicit handling for the StartText and EndText instructions to ensure proper state transitions during matching.

Added unit tests for patterns involving `^` and `$`.