### PR TITLE
Ignore start and end anchors

### DIFF
--- a/src/raw/tests.rs
+++ b/src/raw/tests.rs
@@ -1035,6 +1035,44 @@ mod regex_tests {
         output: vec!["abab", "ababab"],
     }
 
+    // using start/end anchors is a noop
+
+    test_range_with_aut! {
+        fst_range_aut_no_anchor,
+        min: Bound::Unbounded, max: Bound::Unbounded,
+        imin: 0, imax: 1,
+        aut: Regex::new("ab").unwrap(),
+        input: vec!["cab", "ab", "abc", "xyz"],
+        output: vec!["ab"],
+    }
+
+    test_range_with_aut! {
+        fst_range_aut_start_anchor,
+        min: Bound::Unbounded, max: Bound::Unbounded,
+        imin: 0, imax: 1,
+        aut: Regex::new("^ab").unwrap(),
+        input: vec!["cab", "ab", "abc", "xyz"],
+        output: vec!["ab"],
+    }
+
+    test_range_with_aut! {
+        fst_range_aut_end_anchor,
+        min: Bound::Unbounded, max: Bound::Unbounded,
+        imin: 0, imax: 1,
+        aut: Regex::new("ab$").unwrap(),
+        input: vec!["cab", "ab", "abc", "xyz"],
+        output: vec!["ab"],
+    }
+
+    test_range_with_aut! {
+        fst_range_aut_both_anchors,
+        min: Bound::Unbounded, max: Bound::Unbounded,
+        imin: 0, imax: 1,
+        aut: Regex::new("^ab$").unwrap(),
+        input: vec!["cab", "ab", "abc", "xyz"],
+        output: vec!["ab"],
+    }
+
     use proptest::prelude::*;
 
     const REGEX_STRING: &'static str = "[a-c\\.]{0,4}";

--- a/src/raw/tests.rs
+++ b/src/raw/tests.rs
@@ -1073,6 +1073,24 @@ mod regex_tests {
         output: vec!["ab"],
     }
 
+    test_range_with_aut! {
+        fst_range_aut_concatenated_anchor,
+        min: Bound::Unbounded, max: Bound::Unbounded,
+        imin: 0, imax: 2,
+        aut: Regex::new("(\\W|^)ab$").unwrap(),
+        input: vec!["cab", "ab", "abc", "xyz", " ab"],
+        output: vec![" ab", "ab"],
+    }
+
+    test_range_with_aut! {
+        fst_range_aut_impossible_start_anchor,
+        min: Bound::Unbounded, max: Bound::Unbounded,
+        imin: 0, imax: 0,
+        aut: Regex::new("ab^").unwrap(),
+        input: vec!["cab", "ab", "abc", "xyz"],
+        output: vec![],
+    }
+
     use proptest::prelude::*;
 
     const REGEX_STRING: &'static str = "[a-c\\.]{0,4}";

--- a/src/regex/compile.rs
+++ b/src/regex/compile.rs
@@ -1,5 +1,6 @@
 use super::Error;
 use super::Inst;
+use regex_syntax::hir::Look;
 use regex_syntax::hir::{Class, ClassUnicode, ClassUnicodeRange};
 use regex_syntax::hir::{Hir, HirKind};
 use utf8_ranges::{Utf8Sequence, Utf8Sequences};
@@ -95,6 +96,9 @@ impl Compiler {
                     self.set_jump(jmp, j1);
                     self.set_split(split, j2, j3);
                 }
+            }
+            HirKind::Look(Look::Start) | HirKind::Look(Look::End) => {
+                // can be ignored because we always match full strings
             }
             HirKind::Look(_) => return Err(Error::NoEmpty),
         }


### PR DESCRIPTION
As stated in [Regex](https://github.com/SekoiaLab/fst/blob/e83c9a881e387e452814f547e76c72612b9af31b/src/regex/mod.rs#L44-L48):

> /// A regular expression matches a key in a finite state transducer if and only
/// if it matches from the start of a key all the way to end. Stated
/// differently, every regular expression `(re)` is matched as if it were
/// `^(re)$`. This means that if you want to do a substring match, then you
/// must use `.*substring.*`.

This PRs makes the compilation more lenient by ignoring the start and end anchors instead of failing.